### PR TITLE
Fix: remove superfluous output syntax declaration

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,3 @@
-nextflow.preview.output = true
-
 /*
  * Generate BAM index file
  */


### PR DESCRIPTION
Removes the output preview declaration which caused an inscrutable error on older versions of Nextflow. 

Not needed at the moment anyway.