### PR TITLE
Update nf-hello-gatk to match format in hello-gatk training

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: test-pipeline
+
+on: [push, pull_request]
+
+# Cancel if a newer run is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nextflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: setup-nextflow
+        uses: nf-core/setup-nextflow@v1
+
+      - name: run-nextflow
+        run: nextflow run .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: test-pipeline
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 # Cancel if a newer run is started
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  NXF_ANSI_LOG: false
+
 # Cancel if a newer run is started
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/data/sample_bams.txt
+++ b/data/sample_bams.txt
@@ -1,4 +1,3 @@
-id,bam
-mother,https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_mother.bam
-father,https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_father.bam
-son,https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_son.bam
+https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_mother.bam
+https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_father.bam
+https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_son.bam

--- a/data/sample_bams.txt
+++ b/data/sample_bams.txt
@@ -1,3 +1,4 @@
-https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_mother.bam
-https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_father.bam
-https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_son.bam
+id,bam
+mother,https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_mother.bam
+father,https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_father.bam
+son,https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_son.bam

--- a/data/sample_bams.txt
+++ b/data/sample_bams.txt
@@ -1,0 +1,3 @@
+https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_mother.bam
+https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_father.bam
+https://github.com/seqeralabs/nf-hello-gatk/raw/refs/heads/main/data/bam/reads_son.bam

--- a/main.nf
+++ b/main.nf
@@ -187,4 +187,13 @@ workflow {
         ref_index_file,
         ref_dict_file
     )
+
+    BCFTOOLS_STATS(
+        GATK_JOINTGENOTYPING.out[0]
+    )
+
+    MULTIQC(
+        BCFTOOLS_STATS.out.collect(),
+        params.cohort_name
+    )
 }

--- a/main.nf
+++ b/main.nf
@@ -23,7 +23,7 @@ process SAMTOOLS_INDEX {
 
     container 'community.wave.seqera.io/library/samtools:1.20--b5dfbd93de237464'
 
-    publishDir 'results_genomics', mode: 'symlink'
+    publishDir "params.outdir", mode: 'symlink'
 
     input:
         path input_bam
@@ -43,7 +43,7 @@ process GATK_HAPLOTYPECALLER {
 
     container "community.wave.seqera.io/library/gatk4:4.5.0.0--730ee8817e436867"
 
-    publishDir 'results_genomics', mode: 'symlink'
+    publishDir "params.outdir", mode: 'symlink'
 
     input:
         tuple path(input_bam), path(input_bam_index)
@@ -73,7 +73,7 @@ process GATK_JOINTGENOTYPING {
 
     container "community.wave.seqera.io/library/gatk4:4.5.0.0--730ee8817e436867"
 
-    publishDir 'results_genomics', mode: 'symlink'
+    publishDir "params.outdir", mode: 'symlink'
 
     input:
         path all_gvcfs

--- a/main.nf
+++ b/main.nf
@@ -136,8 +136,11 @@ workflow {
     * Pipeline parameters
     */
 
-    // Primary input
-    params.reads_bam = "${workflow.projectDir}/data/sample_bams.txt"
+
+    // Create input channel from samplesheet in CSV format (via CLI parameter)
+    reads_ch = Channel.fromPath(params.reads_bam)
+                        .splitCsv(header: true)
+                        .map{ row -> [row.id, file(row.bam)] }
 
     // Accessory files
     params.reference = "${workflow.projectDir}/data/ref/ref.fasta"

--- a/main.nf
+++ b/main.nf
@@ -16,6 +16,8 @@ params.intervals        = "${projectDir}/data/ref/intervals.bed"
 // Base name for final output file
 params.cohort_name = "family_trio"
 
+params.outdir = "results"
+
 /*
  * Generate BAM index file
  */

--- a/main.nf
+++ b/main.nf
@@ -133,7 +133,7 @@ process MULTIQC {
     container 'community.wave.seqera.io/library/multiqc:1.24.1--789bc3917c8666da'
     conda "bioconda::multiqc=1.24.1"
 
-    publishDir "${$params.outdir}", mode: 'copy'
+    publishDir "$params.outdir", mode: 'copy'
 
     input:
         path input_files

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -19,7 +19,8 @@
         "outdir": {
           "type": "string",
           "description": "Output directory to write results to.",
-          "default": "results"
+          "default": "results",
+          "format": "path"
         },
         "reference": {
           "type": "string",
@@ -36,7 +37,7 @@
           "description": "Path to genome GATK dictionary file (.dict)",
           "format": "file-path"
         },
-        "calling_intervals": {
+        "intervals": {
           "type": "string",
           "description": "Path to intervals for variant calling in BED format (.bed)",
           "format": "file-path"


### PR DESCRIPTION
Changes:
 - Uses samplesheet input (with raw Github URLs)
 - Uses file() on reference data objects instead of channels
 - Uses reads_bam as channel name
 - calling_intervals variable becomes intervals